### PR TITLE
Make graph constructors more type stable

### DIFF
--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -178,13 +178,13 @@ julia> gv = ValDiGraph(path_digraph(3),  edgeval_types=(a=Float64, b=String), ed
    graph value types: ()
 
 julia> ValMatrix(gv, 1, 0.0)
-3×3 ValMatrix{Float64,ValDiGraph{Int64,Tuple{},NamedTuple{(:a, :b),Tuple{Float64,String}},Tuple{},Tuple{},NamedTuple{(:a, :b),Tuple{Array{Array{Float64,1},1},Array{Array{String,1},1}}}},1}:
+3×3 ValMatrix{Float64,ValDiGraph{Int64,Tuple{},NamedTuple{(:a, :b),Tuple{Float64,String}},Tuple{},Tuple{},Tuple{Array{Array{Float64,1},1},Array{Array{String,1},1}}},1}:
  0.0  0.823648  0.0
  0.0  0.0       0.823648
  0.0  0.0       0.0
 
 julia> ValMatrix(gv, :b, nothing)
-3×3 ValMatrix{Union{Nothing, String},ValDiGraph{Int64,Tuple{},NamedTuple{(:a, :b),Tuple{Float64,String}},Tuple{},Tuple{},NamedTuple{(:a, :b),Tuple{Array{Array{Float64,1},1},Array{Array{String,1},1}}}},:b}:
+3×3 ValMatrix{Union{Nothing, String},ValDiGraph{Int64,Tuple{},NamedTuple{(:a, :b),Tuple{Float64,String}},Tuple{},Tuple{},Tuple{Array{Array{Float64,1},1},Array{Array{String,1},1}}},:b}:
  nothing  "1-2"    nothing
  nothing  nothing  "2-3"
  nothing  nothing  nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,14 +77,8 @@ end
 
 
 # TODO check if still correct
-@generated function edgevals_container_type(::Val{E_VAL}) where {E_VAL <:Tuple}
-    R = Tuple{( Adjlist{T} for T in E_VAL.types )...}
-    return :($R)
-end
-
-# TODO check if still correct
-@generated function edgevals_container_type(::Val{E_VAL}) where {E_VAL <:NamedTuple}
-    R = NamedTuple{ Tuple(E_VAL.names), Tuple{( Adjlist{T} for T in E_VAL.types )...}}
+@generated function edgevals_container_type(::Val{E_VALS}) where {E_VALS <: AbstractTuple}
+    R = Tuple{( Adjlist{T} for T in E_VALS.types )...}
     return :($R)
 end
 

--- a/test/integrations/SimpleGraphs.jl
+++ b/test/integrations/SimpleGraphs.jl
@@ -24,7 +24,7 @@ import SimpleValueGraphs: typetuple
         @test g isa ValOutDiGraph{Int32, NamedTuple{(), Tuple{}}, Tuple{}}
         @test g.ne == 4
         @test g.fadjlist == [[], [2, 3], [4], [3]]
-        @test g.vertexvals == NamedTuple()
+        @test g.vertexvals == ()
         @test g.edgevals == ()
     end
 
@@ -37,8 +37,8 @@ import SimpleValueGraphs: typetuple
         @test g.fadjlist == [[], [2, 3], [4], [3]]
         @test g.badjlist == [[], [2], [2, 4], [3]]
         @test g.vertexvals == ()
-        @test g.edgevals == NamedTuple()
-        @test g.redgevals == NamedTuple()
+        @test g.edgevals == ()
+        @test g.redgevals == ()
     end
 
     @testset "ValGraph{UInt64, Tuple{Int32, Float32}, Tuple{}}(gs; vertexvals_init=undef)" begin

--- a/test/interface/constructors.jl
+++ b/test/interface/constructors.jl
@@ -26,6 +26,21 @@ end
 
 =#
 
+@testset "constructor type stability" begin
+
+    @inferred ValGraph(1)
+    @inferred ValDiGraph(1)
+    @inferred ValOutDiGraph(1)
+
+    @inferred ValGraph{Int8}(1)
+    @inferred ValDiGraph{UInt8}(1)
+    @inferred ValOutDiGraph{Int16}(1)
+
+    @inferred ValGraph{Int8, Tuple{Int64, String}, Tuple{}}(1, vertexval_init=undef)
+    @inferred ValDiGraph{UInt8, Tuple{}, @NamedTuple{a::Union{Missing, Int}, b::Vector}}(1)
+    @inferred ValOutDiGraph{Int16, @NamedTuple{a::Int, b::Int}, Tuple{String}}(1, vertexval_init=undef)
+end
+
 #  ------------------------------------------------------
 #  Constructors from other value graphs
 #  ------------------------------------------------------


### PR DESCRIPTION
Also value containers for graphs are now always of type Tuple even if
the graph itself uses NamedTuple for these types.