### PR TITLE
Avoid accessing .names property of NamedTuple

### DIFF
--- a/src/AbstractTuples.jl
+++ b/src/AbstractTuples.jl
@@ -133,7 +133,7 @@ function typetuple_to_type end
 
 typetuple_to_type(tup::TypeTuple) = Tuple{ (T for T in tup)... }
 typetuple_to_type(tup::NamedTypeTuple) =
-    NamedTuple{ Tuple(typeof(tup).names), Tuple{ (T for T in tup)... }}
+    NamedTuple{propertynames(tup), Tuple{ (T for T in tup)... }}
 
 """
     typetuple(::Type{<:Tuple})
@@ -161,7 +161,7 @@ end
 
 function typetuple(TT::Type{<:NamedTuple})
 
-    return NamedTuple{Tuple(TT.names)}(TT.types)
+    return NamedTuple{fieldnames(TT)}(TT.types)
 end
 
 # ======================================================

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -84,7 +84,7 @@ end
 
 # TODO check if still correct
 @generated function edgevals_container_type(::Val{E_VAL}) where {E_VAL <:NamedTuple}
-    R = NamedTuple{ Tuple(E_VAL.names), Tuple{( Adjlist{T} for T in E_VAL.types )...}}
+    R = NamedTuple{ fieldnames(E_VAL), Tuple{( Adjlist{T} for T in E_VAL.types )...}}
     return :($R)
 end
 

--- a/test/testutils.jl
+++ b/test/testutils.jl
@@ -398,9 +398,9 @@ function testset_topological_equivalent(g::SimpleDiGraph, gv::ValDiGraph)
 end
 
 
-allkeys_for_E_VALS(E_VALS::Type{<:Tuple}) = 1:length(E_VALS.types)
-allkeys_for_E_VALS(E_VALS::Type{<:NamedTuple}) = E_VALS.names ∪
-                                                 (1:length(E_VALS.names))
+allkeys_for_E_VALS(E_VALS::Type{<:Tuple}) = 1:fieldcount(E_VALS)
+allkeys_for_E_VALS(E_VALS::Type{<:NamedTuple}) = fieldnames(E_VALS) ∪
+                                                    (1:fieldcount(E_VALS))
 
 
 # ========================================


### PR DESCRIPTION
The `.names` property of a `NamedTuple` cannot be accessed anymore from Julia v1.7 on.